### PR TITLE
Fix url generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**NOTICE** This fork addresses this [open issue](https://github.com/fog/fog-google/issues/590) with `fog-google` that make newer versions of the gem incompatible with our `rma` app. If that issue is fixed, we can stop using this fork and get back on the official gem. We should also pull in upstream changes into this fork when possible.
+
 # Fog::Google
 
 [![Gem Version](https://badge.fury.io/rb/fog-google.svg)](http://badge.fury.io/rb/fog-google) [![Build Status](https://github.com/fog/fog-google/actions/workflows/ruby.yml/badge.svg)](https://github.com/fog/fog-google/actions/workflows/ruby.yml) [![codecov](https://codecov.io/gh/fog/fog-google/branch/master/graph/badge.svg)](https://codecov.io/gh/fog/fog-google) ![Dependabot Status](https://flat.badgen.net/github/dependabot/fog/fog-google) [![Doc coverage](https://inch-ci.org/github/fog/fog-google.svg?branch=master)](https://inch-ci.org/github/fog/fog-google)

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "google-cloud-env", "~> 1.2"
 
+  spec.add_dependency "addressable", ">= 2.7.0"
+
   # Debugger
   # Locked because pry-byebug is broken with 13+
   # see: https://github.com/deivid-rodriguez/pry-byebug/issues/343

--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -1,3 +1,5 @@
+require 'addressable'
+
 module Fog
   module Storage
     class GoogleJSON
@@ -19,10 +21,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          # implementation from CGI.escape, but without ' ' to  '+' conversion
-          params[:path] = params[:path].b.gsub(/([^a-zA-Z0-9_.\-~]+)/) { |m|
-            '%' + m.unpack('H2' * m.bytesize).join('%').upcase
-          }.gsub("%2F", "/")
+          params[:path] = ::Addressable::URI.encode_component(params[:path], ::Addressable::URI::CharacterClasses::PATH)
 
           query = []
 

--- a/test/unit/storage/test_json_requests.rb
+++ b/test/unit/storage/test_json_requests.rb
@@ -49,4 +49,12 @@ class UnitTestJsonRequests < MiniTest::Test
     assert_match(/a\/b\/c/, url,
                  "slashes should not be escaped with '%2F'")
   end
+
+  def test_unescaped_pluses_in_url
+    url = @client.get_object_https_url("bucket",
+                                      "a+c.ext",
+                                      Time.now + 2 * 60)
+    assert_match(/a\+c/, url,
+                 "pluses should not be escaped with '%2B'")
+  end
 end


### PR DESCRIPTION
This addresses https://github.com/fog/fog-google/issues/590, which currently is preventing us from upgrading fog-google to a version that's compatible with Ruby 3 and also handles plus characters correctly in URLs (so we don't run into the issue from https://github.com/footholdtech/rma/pull/4408).

I used the approach that was suggested in https://github.com/fog/fog-google/pull/517 which I believe is a more spec-compliant way of generating URIs than the approach fog-google went with instead.

I also updated the README of this repo to indicate our intentions for not maintaining this fork any further than necessary.

## Testing

I added this fork to our Gemfile in the rma app in https://github.com/footholdtech/rma/tree/fcm-6095-use-fog-google-fork and deployed to a staging instance to test uploads, and confirmed that I was able to upload/download a PDF file with a plus character `+` in the filename, in addition to some other special characters (like spaces, accented characters `á`, and parentheses).